### PR TITLE
refactor: extract NavBar into reusable Header component (#41)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,14 @@ import PatientInfoPage from "./pages/PatientInfoPage.jsx";
 import PatientStatusUpdate from "./pages/PatientStatusUpdate.jsx";
 import PatientStatus from "./pages/PatientStatus.jsx";
 import STMHome from "./pages/STMHome.jsx";
-import NavBar from "./components/layout/NavBar.jsx";
+import Header from "./components/layout/Header.jsx";
 import { PatientProvider } from "./context/PatientProvider";
 
 function App() {
   return (
     <PatientProvider>
       <BrowserRouter>
-        <NavBar />
+        <Header />
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/patient-information" element={<PatientInfoPage />} />

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -16,7 +16,7 @@ import { X } from "lucide-react";
 
 // Add mobile navigation and resposive design
 
-export default function NavBar() {
+export default function Header() {
   return (
     <nav className="flex items-center justify-between px-6 py-3 border-b bg-white shadow-sm transition-all duration-300">
       <h1 className="text-lg font-bold text-gray-900 transform hover:scale-105 transition-transform duration-200 cursor-default">


### PR DESCRIPTION
Moved the existing `NavBar` into a new `Header.jsx` component in components/layout. Updated `App.jsx` to use `<Header />`. No functionality changes — just cleaner layout structure in prep for `MainLayout`.

closes #41 