### PR TITLE
Feature/Update patient status in real time

### DIFF
--- a/src/components/patients/PatientForm.jsx
+++ b/src/components/patients/PatientForm.jsx
@@ -102,7 +102,7 @@ export default function PatientForm() {
 
           // Reset the form and generate a new patient ID for the next entry
           setFormData({
-            status: "checkedIn",
+            status: "Checked In",
             firstName: "",
             lastName: "",
             address: "",

--- a/src/constants/statusLabels.jsx
+++ b/src/constants/statusLabels.jsx
@@ -1,0 +1,15 @@
+{
+  /* This file contains a mapping of internal patient status keys to
+user-friendly display labels used throughout the app for consistent
+ status naming and UI presentation. */
+}
+
+export const STATUS_LABELS = {
+  checkedIn: "Checked In",
+  preProcedure: "Pre-Procedure",
+  inProgress: "In-Progress",
+  closing: "Closing",
+  recovery: "Recovery",
+  complete: "Complete",
+  dismissal: "Dismissal",
+};

--- a/src/pages/PatientStatusUpdate.jsx
+++ b/src/pages/PatientStatusUpdate.jsx
@@ -1,32 +1,72 @@
 import React, { useState, useEffect } from "react";
 import PatientInformationCard from "../components/ui/PatientInformationCard";
 import SearchBar from "../components/layout/SearchBar";
+import { STATUS_LABELS } from "../constants/statusLabels";
 
-//dummy patient data
-const patient = {
-  patientNumber: "12345",
-  firstName: "Jane",
-  lastName: "Doe",
-  address: "123 Walloby Way",
-  city: "Sunnyvale",
-  state: "CA",
-  telephone: "555-123-4567",
-  status: "Checked In",
-};
+const STATUS_ORDER = [
+  "checkedIn",
+  "preProcedure",
+  "inProgress",
+  "closing",
+  "recovery",
+  "complete",
+  "dismissal",
+];
+
 export default function PatientStatusUpdate() {
   const [foundPatient, setFoundPatient] = useState(null);
+  const [newStatus, setNewStatus] = useState("");
+  const [error, setError] = useState("");
+
+  const updatePatientStatus = (patientId, newStatus) => {
+    const patientsString = localStorage.getItem("patients");
+    let patients = {};
+
+    try {
+      patients = JSON.parse(patientsString) || {};
+    } catch (error) {
+      console.error("Failed to parse patients from localStorage:", error);
+      return;
+    }
+
+    // Confirm that the patient exists
+    if (!patients[patientId]) {
+      console.error(`Patient with ID ${patientId} not found`);
+      return;
+    }
+
+    const currentStatus = patients[patientId].status;
+
+    if (currentStatus === newStatus) {
+      console.log("Status is already", newStatus);
+      return;
+    }
+
+    // Update status
+    patients[patientId].status = newStatus;
+
+    // Save back to localStorage
+    localStorage.setItem("patients", JSON.stringify(patients));
+    console.log(`Updated patient ${patientId} status to ${newStatus}`);
+
+    return patients[patientId];
+  };
+
   return (
     <div className="px-4 sm:px-6 md:px-8">
       <h1 className="text-2xl font-bold text-gray-900 text-center mt-16 mb-8">
         Patient Status Update
       </h1>
+
       <div className="flex flex-initial justify-center mt-4 mb-6">
         <SearchBar onPatientFound={setFoundPatient} />
       </div>
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
         <div>
           <PatientInformationCard patient={foundPatient} />
         </div>
+
         <div>
           <div className="flex flex-initial flex-col space-y-4">
             <div className="flex items-center mb-4">
@@ -35,11 +75,12 @@ export default function PatientStatusUpdate() {
               </label>
               <input
                 type="text"
-                value={patient.status}
+                value={foundPatient ? STATUS_LABELS[foundPatient.status] : ""}
                 disabled
                 className="w-64 px-3 py-2 border border-gray-300 rounded-md bg-gray-100 text-gray-700 cursor-not-allowed"
               />
             </div>
+
             <div className="flex items-center mb-4">
               <label className="w-32 text-sm font-medium text-gray-700">
                 New Status
@@ -47,20 +88,71 @@ export default function PatientStatusUpdate() {
               <select
                 id="dropdown"
                 className="w-64 px-3 py-2 border border-gray-300 rounded-md"
+                value={newStatus}
+                onChange={(event) => {
+                  setNewStatus(event.target.value);
+                }}
               >
-                <option value="Checked In">Checked In</option>
-                <option value="Pre-Procedure">Pre-Procedure</option>
-                <option value="In-Progress">In-Progress</option>
-                <option value="Closing">Closing</option>
-                <option value="Recovery">Recovery</option>
-                <option value="Complete">Complete</option>
-                <option value="Dismissal">Dismissal</option>
+                <option value="" disabled>
+                  -- Select a new status --
+                </option>
+                {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
               </select>
             </div>
-            <button className="place-self-center w-6/12 px-4 py-2 bg-black text-white rounded-md shadow-sm hover:bg-gray-200 hover:text-black transition-colors">
+
+            <button
+              className="place-self-center w-6/12 px-4 py-2 bg-black text-white rounded-md shadow-sm hover:bg-gray-200 hover:text-black transition-colors"
+              onClick={() => {
+                if (!newStatus || !foundPatient?.id) {
+                  setError("Please select a patient and a new status.");
+                  return;
+                }
+
+                const currentIndex = STATUS_ORDER.indexOf(foundPatient.status);
+                const newIndex = STATUS_ORDER.indexOf(newStatus);
+
+                if (newIndex === currentIndex) {
+                  setError("The new status is the same as the current status.");
+                  return;
+                }
+
+                if (Math.abs(newIndex - currentIndex) !== 1) {
+                  setError("You can only move one step forward or backward.");
+                  return;
+                }
+
+                const updatedPatient = updatePatientStatus(
+                  foundPatient.id,
+                  newStatus
+                );
+                if (updatedPatient) {
+                  setFoundPatient(updatedPatient);
+                  setNewStatus("");
+                  setError("");
+                } else {
+                  setError("Failed to update patient status.");
+                }
+              }}
+            >
               Update Existing Patient Status
             </button>
-            <button className="place-self-center w-24 px-4 py-2 bg-red-600 text-white text-center rounded-md shadow-sm hover:bg-red-400 hover:text-black transition-colors mt-4">
+
+            {error && (
+              <p className="text-red-600 text-center text-sm mt-2">{error}</p>
+            )}
+
+            <button
+              className="place-self-center w-24 px-4 py-2 bg-red-600 text-white text-center rounded-md shadow-sm hover:bg-red-400 hover:text-black transition-colors mt-4"
+              onClick={() => {
+                setFoundPatient(null);
+                setNewStatus("");
+                setError("");
+              }}
+            >
               Cancel
             </button>
           </div>


### PR DESCRIPTION
This PR implements real time updates to patient status across the UI without requiring a page refresh. It also adds a cancel button that resets the patient form to its default state.

To test locally

1. add/search a patient
2. update their status and watch it update on the info card and current status input. try to skip statuses
3. click cancel to reset the patient info card to default N/A values